### PR TITLE
Update to version 3.1.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Xcode
 #
 # gitignore contributors: remember to update Global/Xcode.gitignore, Objective-C.gitignore & Swift.gitignore
+**/.DS_Store
 
 ## User settings
 xcuserdata/

--- a/Demo/Podfile
+++ b/Demo/Podfile
@@ -4,5 +4,5 @@ target 'Demo' do
   source 'https://cdn.cocoapods.org/'
   source 'git@github.com:berbix/berbix-ios-spec.git'
 
-  pod 'Berbix', '3.0.6'
+  pod 'Berbix', '3.1.0'
 end

--- a/Demo/Podfile
+++ b/Demo/Podfile
@@ -1,8 +1,8 @@
 use_frameworks!
 
 target 'Demo' do
-  source 'https://github.com/CocoaPods/Specs.git'
+  source 'https://cdn.cocoapods.org/'
   source 'git@github.com:berbix/berbix-ios-spec.git'
 
-  pod 'Berbix', '2.0.1'
+  pod 'Berbix', '3.0.6'
 end

--- a/Demo/Podfile.lock
+++ b/Demo/Podfile.lock
@@ -1,16 +1,20 @@
 PODS:
-  - Berbix (3.0.6)
+  - Berbix (3.1.0):
+    - BerbixAdvanced (= 0.2.0)
+  - BerbixAdvanced (0.2.0)
 
 DEPENDENCIES:
-  - Berbix (= 3.0.6)
+  - Berbix (= 3.1.0)
 
 SPEC REPOS:
   "git@github.com:berbix/berbix-ios-spec.git":
     - Berbix
+    - BerbixAdvanced
 
 SPEC CHECKSUMS:
-  Berbix: 442bbf1c299edb3aad3d877f8b72403b33186cf1
+  Berbix: 4437194569af94e5b569cb84b3d8799daf80a221
+  BerbixAdvanced: dd2c799d913ae4e11a854e6713febc38b3493129
 
-PODFILE CHECKSUM: 897d29e3c18a7b81fad28862b46f7df4d26ec402
+PODFILE CHECKSUM: b60c1b7085a13f0ab943a355f2166c2bd7d06f30
 
 COCOAPODS: 1.11.3

--- a/Demo/Podfile.lock
+++ b/Demo/Podfile.lock
@@ -1,23 +1,16 @@
 PODS:
-  - Berbix (2.0.1):
-    - Sentry (~> 6.2.1)
-  - Sentry (6.2.1):
-    - Sentry/Core (= 6.2.1)
-  - Sentry/Core (6.2.1)
+  - Berbix (3.0.6)
 
 DEPENDENCIES:
-  - Berbix (= 2.0.1)
+  - Berbix (= 3.0.6)
 
 SPEC REPOS:
   "git@github.com:berbix/berbix-ios-spec.git":
     - Berbix
-  https://github.com/CocoaPods/Specs.git:
-    - Sentry
 
 SPEC CHECKSUMS:
-  Berbix: a680dee0a0aa2fe337064d09fcb28334509b574a
-  Sentry: 9b922b396b0e0bca8516a10e36b0ea3ebea5faf7
+  Berbix: 442bbf1c299edb3aad3d877f8b72403b33186cf1
 
-PODFILE CHECKSUM: 044f709b64b7d78867f1eb2ef7bde454e9905d8d
+PODFILE CHECKSUM: 897d29e3c18a7b81fad28862b46f7df4d26ec402
 
-COCOAPODS: 1.10.1
+COCOAPODS: 1.11.3


### PR DESCRIPTION
Use the new v3.1.0 version of the Berbix SDK